### PR TITLE
Mirror retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 .idea
 *.iml
 /.unreal-archive.conf
+.*.swp

--- a/src/main/java/net/shrimpworks/unreal/archive/mirror/MirrorClient.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/mirror/MirrorClient.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -36,7 +37,7 @@ public class MirrorClient implements Consumer<MirrorClient.Downloader> {
 	private volatile Thread mirrorThread;
 
 	public MirrorClient(ContentManager content, Path output, int concurrency, Progress progress) {
-		this.content = new ArrayDeque<>(content.search(null, null, null, null));
+		this.content = new ConcurrentLinkedDeque<>(content.search(null, null, null, null));
 		this.output = output;
 		this.concurrency = concurrency;
 


### PR DESCRIPTION
This implements #28, and makes use of concurrent queues. Retry limit is hardcoded to 4 (so 5 tries total).