### PR TITLE
Mirror fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'net.shrimpworks'
-version = "1.3"
+version = "1.4"
 
 mainClassName = 'net.shrimpworks.unreal.archive.Main'
 
@@ -52,7 +52,7 @@ publishing {
 }
 
 dependencies {
-    implementation 'net.shrimpworks:unreal-package-lib:1.4.47+'
+    implementation 'net.shrimpworks:unreal-package-lib:1.4.47'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6'

--- a/src/main/java/net/shrimpworks/unreal/archive/Util.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/Util.java
@@ -68,6 +68,8 @@ public final class Util {
 
 	private static final Pattern UC_WORDS = Pattern.compile("\\b(.)(.*?)\\b");
 
+	private static final int HASH_BUFFER_SIZE = 1024 * 50; // 50kb read buffer
+
 	private Util() { }
 
 	public static String extension(Path path) {
@@ -124,7 +126,7 @@ public final class Util {
 		try (FileChannel channel = FileChannel.open(path, StandardOpenOption.READ)) {
 			MessageDigest md = MessageDigest.getInstance("SHA-1");
 
-			ByteBuffer buffer = ByteBuffer.allocate(4096);
+			ByteBuffer buffer = ByteBuffer.allocate(HASH_BUFFER_SIZE);
 
 			while (channel.read(buffer) > 0) {
 				buffer.flip();

--- a/src/main/java/net/shrimpworks/unreal/archive/content/Content.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/Content.java
@@ -83,6 +83,10 @@ public abstract class Content implements Comparable<Content> {
 	 */
 	public abstract Path contentPath(Path root);
 
+	protected String hashPath() {
+		return String.format("%s/%s/%s", hash.charAt(0), hash.charAt(1), hash.substring(2, 8));
+	}
+
 	/**
 	 * Grouping for pagination and directory partitioning.
 	 * <p>
@@ -109,6 +113,13 @@ public abstract class Content implements Comparable<Content> {
 		return root.resolve(type).resolve(game).resolve(subGrouping()).resolve(name);
 	}
 
+	/**
+	 * Create a friendly name from the content type enum.
+	 * <p>
+	 * NOTE: This is _NOT_ unused; Freemarker templates make use of it in www output.
+	 *
+	 * @return "MAP_PACK" -> "Map Pack"
+	 */
 	public String friendlyContentType() {
 		return Util.capitalWords(this.contentType.toLowerCase().replaceAll("_", " "));
 	}

--- a/src/main/java/net/shrimpworks/unreal/archive/content/mappacks/MapPack.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/mappacks/MapPack.java
@@ -11,7 +11,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class MapPack extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/";
+	private static final String PATH_STRING = "%s/%s/%s/%s/";
 
 	public List<PackMap> maps = new ArrayList<>();
 	public String gametype = "Mixed";
@@ -22,7 +22,8 @@ public class MapPack extends Content {
 		return root.resolve(String.format(PATH_STRING,
 										  game,
 										  "MapPacks",
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/mappacks/MapPack.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/mappacks/MapPack.java
@@ -23,7 +23,7 @@ public class MapPack extends Content {
 										  game,
 										  "MapPacks",
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/maps/Map.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/maps/Map.java
@@ -8,8 +8,8 @@ import net.shrimpworks.unreal.archive.content.Content;
 
 public class Map extends Content {
 
-	// Game/Type/Gametype/A/
-	private static final String PATH_STRING = "%s/%s/%s/%s/";
+	// Game/Type/Gametype/A/[hash]
+	private static final String PATH_STRING = "%s/%s/%s/%s/%s/";
 
 	public String gametype = "Unknown";             // Deathmatch
 	public String title = "Unknown";                // My Map
@@ -39,7 +39,8 @@ public class Map extends Content {
 										  game,
 										  "Maps",
 										  gametype,
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/maps/Map.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/maps/Map.java
@@ -40,7 +40,7 @@ public class Map extends Content {
 										  "Maps",
 										  gametype,
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Model extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/";
+	private static final String PATH_STRING = "%s/%s/%s/%s";
 
 	static final String UT_PLAYER_CLASS = "Botpack.TournamentPlayer";
 
@@ -25,7 +25,8 @@ public class Model extends Content {
 		return root.resolve(String.format(PATH_STRING,
 										  game,
 										  "Models",
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 }

--- a/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
@@ -26,7 +26,7 @@ public class Model extends Content {
 										  game,
 										  "Models",
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 }

--- a/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/models/Model.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Model extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/%s";
+	private static final String PATH_STRING = "%s/%s/%s/%s/";
 
 	static final String UT_PLAYER_CLASS = "Botpack.TournamentPlayer";
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/mutators/Mutator.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/mutators/Mutator.java
@@ -34,7 +34,7 @@ public class Mutator extends Content {
 										  game,
 										  "Mutators",
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/mutators/Mutator.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/mutators/Mutator.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Mutator extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/";
+	private static final String PATH_STRING = "%s/%s/%s/%s/";
 
 	static final String UT_MUTATOR_CLASS = "Engine.Mutator";
 	static final String UT_MENU_CLASS = "UMenu.UMenuModMenuItem";
@@ -33,7 +33,8 @@ public class Mutator extends Content {
 		return root.resolve(String.format(PATH_STRING,
 										  game,
 										  "Mutators",
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
@@ -30,7 +30,7 @@ public class Skin extends Content {
 										  game,
 										  "Skins",
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Skin extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/%s";
+	private static final String PATH_STRING = "%s/%s/%s/%s/";
 
 	static final Pattern NAME_MATCH = Pattern.compile(".+?\\..+?\\d");
 	static final Pattern NAME_MATCH_UNREAL = Pattern.compile(".+?\\.(.+?)");

--- a/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/skins/Skin.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Skin extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/";
+	private static final String PATH_STRING = "%s/%s/%s/%s";
 
 	static final Pattern NAME_MATCH = Pattern.compile(".+?\\..+?\\d");
 	static final Pattern NAME_MATCH_UNREAL = Pattern.compile(".+?\\.(.+?)");
@@ -29,7 +29,8 @@ public class Skin extends Content {
 		return root.resolve(String.format(PATH_STRING,
 										  game,
 										  "Skins",
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 

--- a/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
@@ -24,7 +24,7 @@ public class Voice extends Content {
 										  game,
 										  "Voices",
 										  namePrefix,
-										  this.hash.substring(0, 2)
+										  hashPath()
 		));
 	}
 }

--- a/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Voice extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/%s";
+	private static final String PATH_STRING = "%s/%s/%s/%s/";
 
 	static final Pattern UT_VOICE_MATCH = Pattern.compile("Botpack\\.Voice.+?", Pattern.CASE_INSENSITIVE);
 	static final String UT2_VOICE_CLASS = "XGame.xVoicePack";

--- a/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/content/voices/Voice.java
@@ -10,7 +10,7 @@ import net.shrimpworks.unreal.archive.content.Content;
 public class Voice extends Content {
 
 	// Game/Type/A/
-	private static final String PATH_STRING = "%s/%s/%s/";
+	private static final String PATH_STRING = "%s/%s/%s/%s";
 
 	static final Pattern UT_VOICE_MATCH = Pattern.compile("Botpack\\.Voice.+?", Pattern.CASE_INSENSITIVE);
 	static final String UT2_VOICE_CLASS = "XGame.xVoicePack";
@@ -23,7 +23,8 @@ public class Voice extends Content {
 		return root.resolve(String.format(PATH_STRING,
 										  game,
 										  "Voices",
-										  namePrefix
+										  namePrefix,
+										  this.hash.substring(0, 2)
 		));
 	}
 }

--- a/src/test/java/net/shrimpworks/unreal/archive/content/IndexCleanupUtil.java
+++ b/src/test/java/net/shrimpworks/unreal/archive/content/IndexCleanupUtil.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import net.shrimpworks.unreal.archive.CLI;
 import net.shrimpworks.unreal.archive.Util;
 import net.shrimpworks.unreal.archive.YAML;
 import net.shrimpworks.unreal.archive.content.mappacks.MapPack;
@@ -32,7 +31,6 @@ import net.shrimpworks.unreal.archive.storage.DataStore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static net.shrimpworks.unreal.archive.Main.store;
 import static net.shrimpworks.unreal.archive.content.IndexUtils.UNKNOWN;
 
 public class IndexCleanupUtil {
@@ -462,13 +460,13 @@ public class IndexCleanupUtil {
 	@Test
 	@Disabled
 	public void findDupeFiles() throws IOException {
-		final CLI cli = net.shrimpworks.unreal.archive.CLI.parse(Collections.emptyMap());
-		final DataStore imageStore = store(DataStore.StoreContent.IMAGES, cli);
-		final DataStore attachmentStore = store(DataStore.StoreContent.ATTACHMENTS, cli);
-		final DataStore contentStore = store(DataStore.StoreContent.CONTENT, cli);
-//		final DataStore imageStore = new DataStore.NopStore();
-//		final DataStore attachmentStore = new DataStore.NopStore();
-//		final DataStore contentStore = new DataStore.NopStore();
+//		final CLI cli = net.shrimpworks.unreal.archive.CLI.parse(Collections.emptyMap());
+//		final DataStore imageStore = store(DataStore.StoreContent.IMAGES, cli);
+//		final DataStore attachmentStore = store(DataStore.StoreContent.ATTACHMENTS, cli);
+//		final DataStore contentStore = store(DataStore.StoreContent.CONTENT, cli);
+		final DataStore imageStore = new DataStore.NopStore();
+		final DataStore attachmentStore = new DataStore.NopStore();
+		final DataStore contentStore = new DataStore.NopStore();
 
 		final ContentManager cm = new ContentManager(Paths.get("unreal-archive-data/content/"),
 													 contentStore, imageStore, attachmentStore);


### PR DESCRIPTION
Store files under directories named after their hashes. This prevents overwriting files with duplicate names, both for server-side storage as well as local mirrors.

Local mirrors will be harder to browse through in a file manager, though it's preferable over losing data.

In addition, implemented a process to recover files which may have been impacted by having their files overwritten.


This fixes the issues raised in #27 