### PR TITLE
Sanitize attachment image file names for Windows

### DIFF
--- a/src/main/java/net/shrimpworks/unreal/archive/www/content/ContentPageGenerator.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/www/content/ContentPageGenerator.java
@@ -76,7 +76,7 @@ public abstract class ContentPageGenerator implements PageGenerator {
 
 				// prepend filenames with the content hash, to prevent conflicts
 				String hashName = String.join("_", content.hash.substring(0, 8), img.name);
-				Path outPath = imgPath.resolve(hashName);
+				Path outPath = imgPath.resolve(Util.safeFileName(hashName));
 
 				// only download if it doesn't already exist locally
 				if (!Files.exists(outPath)) Util.downloadTo(img.url, outPath);

--- a/src/main/java/net/shrimpworks/unreal/archive/www/content/GenericContentPage.java
+++ b/src/main/java/net/shrimpworks/unreal/archive/www/content/GenericContentPage.java
@@ -94,7 +94,7 @@ public abstract class GenericContentPage<T extends Content> extends ContentPageG
 
 				// prepend filenames with the content hash, to prevent conflicts
 				String hashName = String.join("_", content.hash.substring(0, 8), img.name);
-				Path outPath = imgPath.resolve(hashName);
+				Path outPath = imgPath.resolve(Util.safeFileName(hashName));
 
 				// only download if it doesn't already exist locally
 				if (!Files.exists(outPath)) Util.downloadTo(img.url, outPath);


### PR DESCRIPTION
Issue #49 

## Background
When generating the site locally on Windows and images are being downloaded, there is at least one image that fails due to an invalid character in the filename (`*`):

```
Failed to download image *SDA_SuperSniper_by_bull*_shot_1.png: java.nio.file.InvalidPathException: Illegal char <*> at index 9: b0dbb7e5_*SDA_SuperSniper_by_bull*_shot_1.png
```

In Linux, it appears `*` can exist fine in the filename but not in Windows. 

## This PR
This PR is using the SafeFileName utility method to sanitize the file name. In my testing, the error is now gone and the image shows correctly on the generated page. The image name is now `b0dbb7e5__SDA_SuperSniper_by_bull__shot_1.png` instead of `b0dbb7e5_*SDA_SuperSniper_by_bull*_shot_1.png`