### PR TITLE
Add error message on connection failure during upload

### DIFF
--- a/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
+++ b/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
@@ -225,6 +225,11 @@
 
 			currentRequest.responseType = 'json';
 
+			currentRequest.onerror = function(e) {
+				alert("Connection error during upload. Please try again.");
+				abortButton.innerText = "Retry upload";
+			};
+
 			// Send POST request to the server side script
 			currentRequest.open('post', url + 'upload');
 


### PR DESCRIPTION
Currently when a connection error occurs during file upload, there is no message shown to the user. This can be confusing as it appears the upload is still processing but behind the scenes, the `.send` call threw an exception and nothing is being uploaded.

## Before: Connection error only shown in console
![Screenshot 2023-02-05 212633](https://user-images.githubusercontent.com/48865951/216906172-813c6c1c-2870-4a29-9c3d-ff6428650cec.jpg)

## After: User facing error shown
![Screenshot 2023-02-05 214543](https://user-images.githubusercontent.com/48865951/216906239-5b7e7db3-4d56-41c2-a5ea-676980bedaeb.jpg)
![Screenshot 2023-02-05 220527](https://user-images.githubusercontent.com/48865951/216906274-99d9bfad-4845-480e-9cea-16e073d13fc1.jpg)

