### PR TITLE
Reset progress bar on reupload

### DIFF
--- a/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
+++ b/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
@@ -236,17 +236,18 @@
 
 		function toggleProgress(progressing) {
 			if (progressing) {
+				progressBar.value = 0;
 				if (!logView.classList.contains("display-block")) logView.classList.add("display-block");
 				if (!progressControls.classList.contains("display-block")) progressControls.classList.add("display-block");
-		  	if (uploadControls.classList.contains("display-block")) uploadControls.classList.remove("display-block");
-		  	if (infoBlurb.classList.contains("display-block")) infoBlurb.classList.remove("display-block");
+				if (uploadControls.classList.contains("display-block")) uploadControls.classList.remove("display-block");
+				if (infoBlurb.classList.contains("display-block")) infoBlurb.classList.remove("display-block");
 				resetLog();
 			} else {
 				if (logView.classList.contains("display-block")) logView.classList.remove("display-block");
 				if (progressControls.classList.contains("display-block")) progressControls.classList.remove("display-block");
 				if (!uploadControls.classList.contains("display-block")) uploadControls.classList.add("display-block");
 				if (filesList.classList.contains("display-block")) filesList.classList.remove("display-block");
-		  	if (!infoBlurb.classList.contains("display-block")) infoBlurb.classList.add("display-block");
+				if (!infoBlurb.classList.contains("display-block")) infoBlurb.classList.add("display-block");
 				history.pushState(null, document.title, '#');
 			}
 		}


### PR DESCRIPTION
Minor issue with slow connections where the progress bar will show 100% for a bit while the reupload is starting which is a bit confusing. This will reset the progress bar back to 0% on reuploads to prevent this.