### PR TITLE
Add max size per upload warning message

### DIFF
--- a/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
+++ b/src/main/resources/net/shrimpworks/unreal/archive/www/submit/index.ftl
@@ -103,6 +103,7 @@
 
 <script type="application/javascript">
 	let url = "../incoming/";
+	let maxUploadSizeGigabytes = 1;
 
 	document.addEventListener("DOMContentLoaded", function() {
 
@@ -162,6 +163,7 @@
 		});
 
 	  fileSelector.addEventListener('change', e => {
+		  let totalSize = 0;
 		  resetFilesList();
 
 		  for (let i = 0; i < e.target.files.length; i++) {
@@ -176,9 +178,15 @@
 			  row.classList.add("file");
 			  row.append(name, size);
 			  filesList.append(row);
+			  totalSize += f.size;
 		  }
 
 		  if (!filesList.classList.contains("display-block")) filesList.classList.add("display-block");
+
+		  if (totalSize >= (maxUploadSizeGigabytes * 1024 * 1024 * 1024)) {
+			  alert("Caution!\n\n" +
+			        "The total max size per upload is " + maxUploadSizeGigabytes + " GB. Reduce the total size of the upload or it may fail.");
+		  }
 	  });
 
 		if (location.hash) {


### PR DESCRIPTION
If a single upload request is greater than 1 GB (found from some rough testing) then the server will return `HTTP 413 Request Entity Too Large` at the very end of the upload. 

This change is adding a warning message if the total file size is greater than 1 GB before the upload is started to prevent uploading content that will fail.

We may need to validate the NGINX config's max request size matches this value to be accurate.

## HTTP 413 example after upload finishes
![image](https://user-images.githubusercontent.com/48865951/218296252-35da7cd8-643d-4a41-87ce-d245a9645308.png)

## After this PR - before upload starts
![image](https://user-images.githubusercontent.com/48865951/218296288-ce84d692-4d5b-4bb4-927b-9a47218425bc.png)
